### PR TITLE
Correcting current tier Legendary Node info

### DIFF
--- a/nodes.json
+++ b/nodes.json
@@ -6168,7 +6168,7 @@
     },
     {
       "id": "labyrinthos-10",
-      "type": "botany",
+      "type": "mining",
       "subType": "legendary",
       "zone": "Labyrinthos",
       "zoneFr": "Labyrinthos",
@@ -6186,7 +6186,7 @@
     },
     {
       "id": "labyrinthos-22",
-      "type": "botany",
+      "type": "mining",
       "subType": "legendary",
       "zone": "Labyrinthos",
       "zoneFr": "Labyrinthos",


### PR DESCRIPTION
Ash Diatomite nodes are currently showing as Botanist nodes on the live site, when they should be Miner nodes.